### PR TITLE
Set OriginalIssuer claim-attribute to IdentityServer's issuer uri.

### DIFF
--- a/src/IdentityServer4.WsFederation/ResponseProcessing/SignInResponseGenerator.cs
+++ b/src/IdentityServer4.WsFederation/ResponseProcessing/SignInResponseGenerator.cs
@@ -11,16 +11,17 @@ using IdentityServer4.Stores;
 using IdentityServer4.WsFederation.Validation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Protocols.WsFederation;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Tokens.Saml;
-using Microsoft.IdentityModel.Tokens.Saml2;
 using System;
 using System.Collections.Generic;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Saml;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.WsFederation;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace IdentityServer4.WsFederation
 {
@@ -132,7 +133,7 @@ namespace IdentityServer4.WsFederation
             }
 
             // authentication instant claim is required
-            outboundClaims.Add(new Claim(ClaimTypes.AuthenticationInstant, XmlConvert.ToString(DateTime.UtcNow, "yyyy-MM-ddTHH:mm:ss.fffZ"), ClaimValueTypes.DateTime, Issuer));
+            outboundClaims.Add(new Claim(ClaimTypes.AuthenticationInstant, XmlConvert.ToString(result.User.GetAuthenticationTime(), "yyyy-MM-ddTHH:mm:ss.fffZ"), ClaimValueTypes.DateTime, Issuer));
 
             return new ClaimsIdentity(outboundClaims, "idsrv");
         }


### PR DESCRIPTION
I recently adapted your sample as WS-Federation signin implementation for the IdentityServer of my organization. After taking the the new release to production I had a client who complained that the claim mapping doesn't work anymore at his side.

He got this error page on client-side:
![image](https://user-images.githubusercontent.com/20394732/103092617-1d41f580-45f8-11eb-8ec6-5792b9d78265.png)

After some investigation I realized the problem is that the attribute `a:OriginalIssuer` of saml:Attribute in the WS-Federation response is set to `LOCAL AUTHORITY` instead of the correct issuer uri of our IdentityServer. I found out that `LOCAL AUTHORITY` is just the default value for this attribute in the Claim class in System.Security.Claims (see this [StackOverflow](https://stackoverflow.com/a/53074693)).

Setting the OriginalIssuer-attribute of each claim to the right issuer uri of IdentityServer solved the problem. I created this PR to share the solution with you.

Sample WS-Federation response:

Before:
```
<saml:Attribute AttributeName="name" AttributeNamespace="http://schemas.xmlsoap.org/ws/2005/05/identity/claims" a:OriginalIssuer="LOCAL AUTHORITY" xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
    <saml:AttributeValue>Bob Smith</saml:AttributeValue>
</saml:Attribute>
```

After:
```
<saml:Attribute AttributeName="name" AttributeNamespace="http://schemas.xmlsoap.org/ws/2005/05/identity/claims" a:OriginalIssuer="http://localhost:5000" xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
    <saml:AttributeValue>Bob Smith</saml:AttributeValue>
</saml:Attribute>
```

Why didn't this happen with the [official sample for .NET Framework](https://github.com/IdentityServer/IdentityServer4.WsFederation)?
Because the OriginalIssuer attribute wasn't there. It seems to be a new behavior that was introduced with the AzureAD IdentityModel library.