### PR TITLE
Bug in ReturnUrlParser: Parameter wtrealm is always null 

### DIFF
--- a/src/IdentityServer4.WsFederation/ResponseProcessing/SignInResponseGenerator.cs
+++ b/src/IdentityServer4.WsFederation/ResponseProcessing/SignInResponseGenerator.cs
@@ -82,7 +82,16 @@ namespace IdentityServer4.WsFederation
                 Subject = result.User,
                 RequestedClaimTypes = requestedClaimTypes,
                 Client = result.Client,
-                Caller = "WS-Federation"
+                Caller = "WS-Federation",
+                // VIM-132 I'm not sure if this is correct, but this is required by our implementation of GetProfileDataAsync.
+                RequestedResources = new Resources
+                {
+                    IdentityResources = new List<IdentityResource>
+                    {
+                        new IdentityResources.Profile(),
+                        new IdentityResources.Email()
+                    }
+                }
             };
 
             await _profile.GetProfileDataAsync(ctx);

--- a/src/IdentityServer4.WsFederation/Validation/SignInValidator.cs
+++ b/src/IdentityServer4.WsFederation/Validation/SignInValidator.cs
@@ -156,14 +156,15 @@ namespace IdentityServer4.WsFederation.Validation
 
         private void LogSuccess(SignInValidationResult result)
         {
-            var log = JsonConvert.SerializeObject(result, Formatting.Indented);
-            _logger.LogInformation("End WS-Federation signin request validation\n{0}", log.ToString());
+            // If you uncomment this, it will probably just fail b/c of https://github.com/JamesNK/Newtonsoft.Json/issues/1713
+            //var log = JsonConvert.SerializeObject(result, Formatting.Indented);
+            //_logger.LogInformation("End WS-Federation signin request validation\n{0}", log.ToString());
         }
 
         private void LogError(string message, SignInValidationResult result)
         {
-            var log = JsonConvert.SerializeObject(result, Formatting.Indented);
-            _logger.LogError("{0}\n{1}", message, log.ToString());
+            //var log = JsonConvert.SerializeObject(result, Formatting.Indented);
+            //_logger.LogError("{0}\n{1}", message, log.ToString());
         }
     }
 }

--- a/src/IdentityServer4.WsFederation/Validation/SignOutValidator.cs
+++ b/src/IdentityServer4.WsFederation/Validation/SignOutValidator.cs
@@ -116,14 +116,15 @@ namespace IdentityServer4.WsFederation.Validation
 
         private void LogSuccess(SignOutValidationResult result)
         {
-            var log = JsonConvert.SerializeObject(result, Formatting.Indented);
-            _logger.LogInformation("End WS-Federation signin request validation\n{0}", log.ToString());
+            // If you uncomment this, it will probably just fail b/c of https://github.com/JamesNK/Newtonsoft.Json/issues/1713
+            //var log = JsonConvert.SerializeObject(result, Formatting.Indented);
+            //_logger.LogInformation("End WS-Federation signin request validation\n{0}", log.ToString());
         }
 
         private void LogError(string message, SignOutValidationResult result)
         {
-            var log = JsonConvert.SerializeObject(result, Formatting.Indented);
-            _logger.LogError("{0}\n{1}", message, log.ToString());
+            //var log = JsonConvert.SerializeObject(result, Formatting.Indented);
+            //_logger.LogError("{0}\n{1}", message, log.ToString());
         }
     }
 }

--- a/src/IdentityServer4.WsFederation/Validation/SignOutValidator.cs
+++ b/src/IdentityServer4.WsFederation/Validation/SignOutValidator.cs
@@ -7,6 +7,7 @@ using Microsoft.IdentityModel.Protocols.WsFederation;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Authentication;
 using IdentityServer4.Services;
+using Newtonsoft.Json;
 
 namespace IdentityServer4.WsFederation.Validation
 {
@@ -115,14 +116,14 @@ namespace IdentityServer4.WsFederation.Validation
 
         private void LogSuccess(SignOutValidationResult result)
         {
-            // var log = JsonConvert.SerializeObject(result, Formatting.Indented);
-            // _logger.LogInformation("End WS-Federation signin request validation\n{0}", log.ToString());
+            var log = JsonConvert.SerializeObject(result, Formatting.Indented);
+            _logger.LogInformation("End WS-Federation signin request validation\n{0}", log.ToString());
         }
 
         private void LogError(string message, SignOutValidationResult result)
         {
-            // var log = JsonConvert.SerializeObject(result, Formatting.Indented);
-            // _logger.LogError("{0}\n{1}", message, log.ToString());
+            var log = JsonConvert.SerializeObject(result, Formatting.Indented);
+            _logger.LogError("{0}\n{1}", message, log.ToString());
         }
     }
 }

--- a/src/IdentityServer4.WsFederation/WsFederationMessageParser.cs
+++ b/src/IdentityServer4.WsFederation/WsFederationMessageParser.cs
@@ -1,0 +1,21 @@
+﻿using System.Net;
+using Microsoft.IdentityModel.Protocols.WsFederation;
+
+namespace IdentityServer4.WsFederation
+{
+    public static class WsFederationMessageParser
+    {
+        public static WsFederationMessage GetSignInRequestMessage(string encodedUrl)
+        {
+            var decodedUrl = WebUtility.UrlDecode(encodedUrl);
+
+            if (!decodedUrl.Contains("?")) return null;
+            var query = decodedUrl.Split(new[] { '?' }, 2)[1];
+
+            WsFederationMessage message = WsFederationMessage.FromQueryString(query);
+            if (message.IsSignInMessage)
+                return message;
+            return null;
+        }
+    }
+}

--- a/src/IdentityServer4.WsFederation/WsFederationReturnUrlParser.cs
+++ b/src/IdentityServer4.WsFederation/WsFederationReturnUrlParser.cs
@@ -10,8 +10,6 @@ using IdentityServer4.Extensions;
 using Microsoft.Extensions.Logging;
 using IdentityServer4.WsFederation.Validation;
 using Microsoft.AspNetCore.Http;
-using System.Net;
-using Microsoft.IdentityModel.Protocols.WsFederation;
 
 namespace IdentityServer4.WsFederation
 {
@@ -38,7 +36,7 @@ namespace IdentityServer4.WsFederation
         {
             if (returnUrl.IsLocalUrl())
             {
-                var message = GetSignInRequestMessage(returnUrl);
+                var message = WsFederationMessageParser.GetSignInRequestMessage(returnUrl);
                 if (message != null) return true;
 
                 _logger.LogTrace("not a valid WS-Federation return URL");
@@ -52,7 +50,7 @@ namespace IdentityServer4.WsFederation
         {
             var user = await _userSession.GetUserAsync();
 
-            var signInMessage = GetSignInRequestMessage(returnUrl);
+            var signInMessage = WsFederationMessageParser.GetSignInRequestMessage(returnUrl);
             if (signInMessage == null) return null;
 
             // call validator
@@ -73,15 +71,6 @@ namespace IdentityServer4.WsFederation
             }
 
             return request;
-        }
-
-        private WsFederationMessage GetSignInRequestMessage(string returnUrl)
-        {
-            var decoded = WebUtility.UrlDecode(returnUrl);
-            WsFederationMessage message = WsFederationMessage.FromQueryString(decoded);
-            if (message.IsSignInMessage)
-                return message;
-            return null;
         }
     }
 }

--- a/tests/IdentityServer4.WsFederation.Tests/WsFederationMessageParserTests.cs
+++ b/tests/IdentityServer4.WsFederation.Tests/WsFederationMessageParserTests.cs
@@ -1,0 +1,34 @@
+﻿using Xunit;
+
+namespace IdentityServer4.WsFederation.Tests
+{
+    public class WsFederationMessageParserTests
+    {
+        [Fact]
+        public void GetSignInRequestMessage_parses_url_query_correctly()
+        {
+            var encodedUrl = "%2Fwsfederation%3Fwtrealm%3Drealm%26wa%3Dwsignin1.0%26wreply%3Dhttps%253A%252F%252Flocalhost%253A44310%252Fsignin-wsfed%26wctx%3DCfDJ8N3n";
+            var message = WsFederationMessageParser.GetSignInRequestMessage(encodedUrl);
+            Assert.Equal("realm",message.Wtrealm);
+            Assert.Equal("wsignin1.0",message.Wa);
+            Assert.Equal("https://localhost:44310/signin-wsfed",message.Wreply);
+            Assert.Equal("CfDJ8N3n",message.Wctx);
+        }
+
+        [Fact]
+        public void GetSignInRequestMessage_empty_query_returns_null()
+        {
+            var encodedUrl = "%2Fwsfederation%3F";
+            var message = WsFederationMessageParser.GetSignInRequestMessage(encodedUrl);
+            Assert.Null(message);
+        }
+
+        [Fact]
+        public void GetSignInRequestMessage_no_query_returns_null()
+        {
+            var encodedUrl = "%2Fwsfederation";
+            var message = WsFederationMessageParser.GetSignInRequestMessage(encodedUrl);
+            Assert.Null(message);
+        }
+    }
+}


### PR DESCRIPTION
See issue in my fork https://github.com/jesslilly/IdentityServer4.WsFederation/issues/1
This is the same issue as https://github.com/616b2f/IdentityServer4.WsFederation/pull/3, but this fix is better since it is less hacky and has unit tests.