### PR TITLE
Fix no auth provider found

### DIFF
--- a/samples/clients/AspNetCoreWsFederation/Startup.cs
+++ b/samples/clients/AspNetCoreWsFederation/Startup.cs
@@ -16,10 +16,10 @@ namespace AspNetCoreSecurity
             services.AddMvc();
 
             services.AddAuthentication(options =>
-            {
-                options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = WsFederationDefaults.AuthenticationScheme;
-            })
+                {
+                    options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                    options.DefaultChallengeScheme = WsFederationDefaults.AuthenticationScheme;
+                })
                 .AddCookie(options =>
                 {
                     options.Cookie.Name = "aspnetcorewsfed";

--- a/samples/server/IdentityServer4.WsFederation/Startup.cs
+++ b/samples/server/IdentityServer4.WsFederation/Startup.cs
@@ -22,7 +22,8 @@ namespace IdentityServer4.WsFederation
                 .AddInMemoryApiResources(Config.GetApiResources())
                 .AddInMemoryClients(Config.GetClients())
                 .AddTestUsers(TestUsers.Users)
-                .AddWsFederation();
+                .AddWsFederation()
+                .AddInMemoryRelyingParties(Config.GetRelyingParties());
 
             services.AddAuthentication()
                 .AddGoogle("Google", "Google", options =>

--- a/src/IdentityServer4.WsFederation/WsFederationReturnUrlParser.cs
+++ b/src/IdentityServer4.WsFederation/WsFederationReturnUrlParser.cs
@@ -63,7 +63,7 @@ namespace IdentityServer4.WsFederation
             var request = new AuthorizationRequest()
             {
                 ClientId = result.Client.ClientId,
-                IdP = result.WsFederationMessage.Wtrealm,
+                IdP = result.WsFederationMessage.Whr,
                 RedirectUri = result.WsFederationMessage.Wreply
             };
 

--- a/tests/IdentityServer4.WsFederation.Tests/FakeAccountController.cs
+++ b/tests/IdentityServer4.WsFederation.Tests/FakeAccountController.cs
@@ -14,10 +14,12 @@ namespace IdentityServer4.WsFederation.Tests
         private readonly TestUserStore _userStore;
         private readonly IIdentityServerInteractionService _interaction;
 
-        public FakeAccountController(TestUserStore userStore)
+        public FakeAccountController(
+            TestUserStore userStore,
+            IIdentityServerInteractionService interaction)
         {
             _userStore = userStore;
-            
+            _interaction = interaction;
         }
 
         [HttpGet]


### PR DESCRIPTION
Issue was mentioned in #3 and bring up this issue after we corrected wsfed sign-in request message parsing issue.

The problem was that we mapped wrong wsfed sign-in request parameter to  AuthenticationRequest.IdP parameter.

@doeringp thx for bringing this up!