### PR TITLE
Fix for URL parsing from doeringp requires UrlDecode

### DIFF
--- a/src/IdentityServer4.WsFederation/WsFederationMessageParser.cs
+++ b/src/IdentityServer4.WsFederation/WsFederationMessageParser.cs
@@ -1,0 +1,21 @@
+﻿using System.Net;
+using Microsoft.IdentityModel.Protocols.WsFederation;
+
+namespace IdentityServer4.WsFederation
+{
+    public static class WsFederationMessageParser
+    {
+        public static WsFederationMessage GetSignInRequestMessage(string encodedUrl)
+        {
+            var decodedUrl = WebUtility.UrlDecode(encodedUrl);
+
+            if (!decodedUrl.Contains("?")) return null;
+            var query = decodedUrl.Split(new[] { '?' }, 2)[1];
+
+            WsFederationMessage message = WsFederationMessage.FromQueryString(query);
+            if (message.IsSignInMessage)
+                return message;
+            return null;
+        }
+    }
+}

--- a/src/IdentityServer4.WsFederation/WsFederationMessageParser.cs
+++ b/src/IdentityServer4.WsFederation/WsFederationMessageParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using Microsoft.IdentityModel.Protocols.WsFederation;
 
 namespace IdentityServer4.WsFederation
@@ -8,11 +9,9 @@ namespace IdentityServer4.WsFederation
         public static WsFederationMessage GetSignInRequestMessage(string encodedUrl)
         {
             var decodedUrl = WebUtility.UrlDecode(encodedUrl);
-
-            if (!decodedUrl.Contains("?")) return null;
-            var query = decodedUrl.Split(new[] { '?' }, 2)[1];
-
-            WsFederationMessage message = WsFederationMessage.FromQueryString(query);
+            // Fix: Add dummy.com host so Uri can properly parse out the query string.
+            var uri = new Uri("https://dummy.com" + decodedUrl);
+            WsFederationMessage message = WsFederationMessage.FromUri(uri);;
             if (message.IsSignInMessage)
                 return message;
             return null;

--- a/src/IdentityServer4.WsFederation/WsFederationReturnUrlParser.cs
+++ b/src/IdentityServer4.WsFederation/WsFederationReturnUrlParser.cs
@@ -10,8 +10,6 @@ using IdentityServer4.Extensions;
 using Microsoft.Extensions.Logging;
 using IdentityServer4.WsFederation.Validation;
 using Microsoft.AspNetCore.Http;
-using System.Net;
-using Microsoft.IdentityModel.Protocols.WsFederation;
 
 namespace IdentityServer4.WsFederation
 {
@@ -38,7 +36,7 @@ namespace IdentityServer4.WsFederation
         {
             if (returnUrl.IsLocalUrl())
             {
-                var message = GetSignInRequestMessage(returnUrl);
+                var message = WsFederationMessageParser.GetSignInRequestMessage(returnUrl);
                 if (message != null) return true;
 
                 _logger.LogTrace("not a valid WS-Federation return URL");
@@ -52,7 +50,7 @@ namespace IdentityServer4.WsFederation
         {
             var user = await _userSession.GetUserAsync();
 
-            var signInMessage = GetSignInRequestMessage(returnUrl);
+            var signInMessage = WsFederationMessageParser.GetSignInRequestMessage(returnUrl);
             if (signInMessage == null) return null;
 
             // call validator
@@ -73,15 +71,6 @@ namespace IdentityServer4.WsFederation
             }
 
             return request;
-        }
-
-        private WsFederationMessage GetSignInRequestMessage(string returnUrl)
-        {
-            var decoded = WebUtility.UrlDecode(returnUrl);
-            WsFederationMessage message = WsFederationMessage.FromQueryString(decoded);
-            if (message.IsSignInMessage)
-                return message;
-            return null;
         }
     }
 }

--- a/tests/IdentityServer4.WsFederation.Tests/WsFederationMessageParserTests.cs
+++ b/tests/IdentityServer4.WsFederation.Tests/WsFederationMessageParserTests.cs
@@ -1,0 +1,34 @@
+﻿using Xunit;
+
+namespace IdentityServer4.WsFederation.Tests
+{
+    public class WsFederationMessageParserTests
+    {
+        [Fact]
+        public void GetSignInRequestMessage_parses_url_query_correctly()
+        {
+            var encodedUrl = "%2Fwsfederation%3Fwtrealm%3Drealm%26wa%3Dwsignin1.0%26wreply%3Dhttps%253A%252F%252Flocalhost%253A44310%252Fsignin-wsfed%26wctx%3DCfDJ8N3n";
+            var message = WsFederationMessageParser.GetSignInRequestMessage(encodedUrl);
+            Assert.Equal("realm",message.Wtrealm);
+            Assert.Equal("wsignin1.0",message.Wa);
+            Assert.Equal("https://localhost:44310/signin-wsfed",message.Wreply);
+            Assert.Equal("CfDJ8N3n",message.Wctx);
+        }
+
+        [Fact]
+        public void GetSignInRequestMessage_empty_query_returns_null()
+        {
+            var encodedUrl = "%2Fwsfederation%3F";
+            var message = WsFederationMessageParser.GetSignInRequestMessage(encodedUrl);
+            Assert.Null(message);
+        }
+
+        [Fact]
+        public void GetSignInRequestMessage_no_query_returns_null()
+        {
+            var encodedUrl = "%2Fwsfederation";
+            var message = WsFederationMessageParser.GetSignInRequestMessage(encodedUrl);
+            Assert.Null(message);
+        }
+    }
+}


### PR DESCRIPTION
Hi Alexej,

I think I did the pull request correctly this time.  The fix you merged in from doeringp does not pass the unit tests I made.  We must still call UrlDecode so that "new Uri" will work correctly.  I did use doeringp's good idea to use a dummy.com host since it just makes the URI parsing easier and uses less code.  Does not rely on parsing for a question mark.

Also I like having these tests.  I the other tests in the solution do not cover this issue.

![image](https://user-images.githubusercontent.com/1406490/109511243-d85f9280-7a70-11eb-8443-5b2001dc438b.png)

When I add decode back, the new tests pass.

![image](https://user-images.githubusercontent.com/1406490/109511399-fe853280-7a70-11eb-94fa-fcca47d70b62.png)

Also, there should be a comment why we use a dummy URL.

Thank you.  I hope this PR is merged.  😄 
